### PR TITLE
add `--renderer` arg which takes `textual`/`graphical`

### DIFF
--- a/code/.cargo/config
+++ b/code/.cargo/config
@@ -1,6 +1,10 @@
 [source.crates-io]
 replace-with = "vendored-sources"
 
+[source."https://github.com/sunjay/turtle"]
+git = "https://github.com/sunjay/turtle"
+rev = "268e005665ecac48a96c5833e0b9d09f538f076b"
+replace-with = "vendored-sources"
+
 [source.vendored-sources]
 directory = "vendor"
-

--- a/code/examplar-renderer/Cargo.toml
+++ b/code/examplar-renderer/Cargo.toml
@@ -8,4 +8,9 @@ edition = "2018"
 
 [dependencies]
 api = { path = "../api" }
-turtle = "^1.0.0-rc.2"
+# turtle = "^1.0.0-rc.2"
+# use this version from github that is newer than above version, as above version does not compile due to
+# an issue in the cocoa library which is a transitive dependency
+turtle = { git = "https://github.com/sunjay/turtle", rev = "268e005665ecac48a96c5833e0b9d09f538f076b" }
+
+

--- a/code/src/main.rs
+++ b/code/src/main.rs
@@ -1,52 +1,89 @@
+use api::{LSystem, Symbol};
+use clap::{arg_enum, value_t, App, Arg};
 use interpreter::Interpreter;
 use parser::parse;
-use api::{LSystem, Symbol};
-use renderer::{ Renderer, StringRenderer };
-// use renderer::crab::Crab; // Uncomment to use the Crab renderer
+use renderer::crab::Crab;
+use renderer::{Renderer, StringRenderer};
 use std::fmt::Debug;
+use std::fs::read_to_string;
 use std::hash::Hash;
-use std::fs::{read_to_string};
-use clap::{App, Arg};
+
+arg_enum! {
+    #[derive(PartialEq, Debug)]
+    pub enum RendererKind {
+        Textual,
+        Graphical
+    }
+}
 
 fn main() {
-    // Uncomment to use the Crab renderer
-    // Crab::global_init();
+    Crab::global_init();
 
     let parsed_args = App::new("l-sysem")
-            .about("Renders an l-system")
-            .arg(Arg::with_name("iterations")
-                    .short("n")
-                    .long("iterations")
-                    .takes_value(true)
-                    .default_value("1")
-                    .help("The number of token replacement iterations to perform"))
-            .arg(Arg::with_name("l-system-file")
-                    .short("f")
-                    .long("file")
-                    .takes_value(true)
-                    .required(true)
-                    .help("file containing the complete description of the l-system"))
-            .get_matches();
+        .about("Renders an l-system")
+        .arg(
+            Arg::with_name("iterations")
+                .short("n")
+                .long("iterations")
+                .takes_value(true)
+                .default_value("1")
+                .help("The number of token replacement iterations to perform"),
+        )
+        .arg(
+            Arg::with_name("l-system-file")
+                .short("f")
+                .long("file")
+                .takes_value(true)
+                .required(true)
+                .help("file containing the complete description of the l-system"),
+        )
+        .arg(
+            Arg::with_name("renderer")
+                .short("r")
+                .long("renderer")
+                .takes_value(true)
+                .required(false)
+                .default_value("textual")
+                .possible_values(&RendererKind::variants())
+                .case_insensitive(true)
+                .help("kind of renderer to use"),
+        )
+        .get_matches();
 
-    let iterations = parsed_args.value_of("iterations").unwrap().parse::<usize>().unwrap_or_else(|_| {
-        eprintln!("iterations argument must be a positive integer");
-        ::std::process::exit(1);
-    });
+    let iterations = parsed_args
+        .value_of("iterations")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap_or_else(|_| {
+            eprintln!("iterations argument must be a positive integer");
+            ::std::process::exit(1);
+        });
     let file_name = parsed_args.value_of("l-system-file").unwrap(); // safe unwrap since l-system-file is required
     let input = read_to_string(file_name).unwrap();
 
-    let system = parse(&input)
-        .expect("Failed to parse definition of L-system");
+    let system = parse(&input).expect("Failed to parse definition of L-system");
 
-    let writer = std::io::stdout();
-    let mut renderer = StringRenderer::new(writer);
-    // uncomment to use the crab renderer
-    // let mut renderer = Crab::new(system.render_config.clone());
+    let renderer_kind = value_t!(parsed_args, "renderer", RendererKind).unwrap_or_else(|_| {
+        ::std::process::exit(1);
+    });
 
-    render(system, iterations, &mut renderer);
+    match renderer_kind {
+        RendererKind::Textual => {
+            let writer = std::io::stdout();
+            let mut renderer = StringRenderer::new(writer);
+            render(system, iterations, &mut renderer);
+        }
+        RendererKind::Graphical => {
+            let mut renderer = Crab::new(system.render_config.clone());
+            render(system, iterations, &mut renderer);
+        }
+    };
 }
 
-fn render<T: Symbol>(system: LSystem<T>, iterations: usize, renderer: &mut impl Renderer) where T: Copy + Eq + Debug + Hash {
+fn render<T: Symbol>(system: LSystem<T>, iterations: usize, renderer: &mut impl Renderer)
+where
+    T: Copy + Eq + Debug + Hash,
+{
     let interpreter = Interpreter::new(system);
     for symbol in interpreter.level(iterations) {
         renderer.render(symbol);


### PR DESCRIPTION
- note that needed to use pinned version of turtle to work around a build issue with `cocoa` library